### PR TITLE
Remove cpuid_check

### DIFF
--- a/src/domain.ml
+++ b/src/domain.ml
@@ -969,11 +969,3 @@ let cpuid_set ~xc ~hvm domid cfg =
 
 let cpuid_apply ~xc ~hvm domid =
 	Xc.domain_cpuid_apply xc domid hvm
-
-let cpuid_check cfg =
-	let tmp = Array.create 4 None in
-	List.map (fun (node, constr) ->
-		cpuid_cfg_to_xc_cpuid_cfg tmp constr;
-		let (success, cfgout) = Xc.cpuid_check node tmp in
-		(success, (node, (cpuid_cfg_of_xc_cpuid_cfg cfgout)))
-	) cfg

--- a/src/domain.mli
+++ b/src/domain.mli
@@ -206,4 +206,3 @@ val cpuid_rtype_of_char : char -> cpuid_rtype
 
 val cpuid_set : xc: Xc.handle -> hvm: bool -> domid -> cpuid_config -> cpuid_config
 val cpuid_apply : xc: Xc.handle -> hvm: bool -> domid -> unit
-val cpuid_check : cpuid_config -> (bool * ((int64 * int64 option) * (cpuid_reg * cpuid_rtype array) list)) list


### PR DESCRIPTION
It is unused, and the underlying libxc call is conceptually broken.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>